### PR TITLE
Shifted length in the popMethod before appending the return object

### DIFF
--- a/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
+++ b/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
@@ -64,13 +64,15 @@ public class Hugo {
 
     StringBuilder builder = new StringBuilder().append("⇠ ")
         .append(methodName);
+        
+    builder.append(" [")
+        .append(lengthMillis)
+        .append("ms]");
+        
     if (hasReturnType) {
       builder.append(" = ");
       appendObject(builder, result);
     }
-    builder.append(" [")
-        .append(lengthMillis)
-        .append("ms]");
 
     Log.d(asTag(className), builder.toString());
   }


### PR DESCRIPTION
This will allow the user to see the time even if they have a return longer than the Logcat buffer. PR for Fixes #11
