### PR TITLE
Removed targetSDKVersion from AndroidManifest.xml

### DIFF
--- a/hugo-runtime/src/main/AndroidManifest.xml
+++ b/hugo-runtime/src/main/AndroidManifest.xml
@@ -7,8 +7,7 @@
     >
 
   <uses-sdk
-      android:minSdkVersion="9"
-      android:targetSdkVersion="19"/>
+      android:minSdkVersion="9"/>
 
   <application/>
 </manifest>


### PR DESCRIPTION
Removed the targetSDKVersion property for compatibility with other libraries.
