### PR TITLE
Use same gradle version for hugo-example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,20 +18,6 @@ allprojects {
   apply plugin: 'maven'
 }
 
-task cleanExample(type: Exec) {
-  executable = 'gradle'
-  workingDir = project.file('hugo-example')
-  args = [ 'clean' ]
-}
-
-task assembleExample(type: Exec) {
-  executable = 'gradle'
-  workingDir = project.file('hugo-example')
-  args = [ 'assemble' ]
-}
-
-task installExample(type: Exec) {
-  executable = 'gradle'
-  workingDir = project.file('hugo-example')
-  args = [ 'installDebug' ]
-}
+task cleanExample(dependsOn: ':hugo-example:assemble')
+task assembleExample(dependsOn: ':hugo-example:assemble')
+task installExample(dependsOn: ':hugo-example:assemble')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 include ':hugo-annotations'
 include ':hugo-plugin'
 include ':hugo-runtime'
+include ':hugo-example'


### PR DESCRIPTION
There is a bug when the following tasks are executed:
- cleanExample
- assembleExample
- installExample

In these tasks the gradle of the system is used instead of gradlew.
This leads to strange errors when the two versions are different.

Three possible corrections.
1. Change the command to execute from gradle to ../gradlew in
   build.gradle
   
   task cleanExample(type: Exec) {
     executable = '../gradlew'
     workingDir = project.file('hugo-example')
     ...
2. Make the cleanExample task depend on :hugo-example:clean task
   
   task cleanExample(dependsOn: ':hugo-example:assemble')
3. Change the documentation in README.md to directly do the commands of
   subprojects
   
   ./gradlew hugo-example:cleanExample

This commit implements the second option but please advise.
