### PR TITLE
Use gradlew for hugo-example (not gradle of OS)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,19 +19,19 @@ allprojects {
 }
 
 task cleanExample(type: Exec) {
-  executable = 'gradle'
+  executable = '../gradlew'
   workingDir = project.file('hugo-example')
   args = [ 'clean' ]
 }
 
 task assembleExample(type: Exec) {
-  executable = 'gradle'
+  executable = '../gradlew'
   workingDir = project.file('hugo-example')
   args = [ 'assemble' ]
 }
 
 task installExample(type: Exec) {
-  executable = 'gradle'
+  executable = '../gradlew'
   workingDir = project.file('hugo-example')
   args = [ 'installDebug' ]
 }


### PR DESCRIPTION
There is a bug when the following tasks are executed:

cleanExample
assembleExample
installExample
In these tasks the gradle of the system is used instead of gradlew.
This leads to strange errors when the two versions are different.

The simple correction consisted on changing the command to execute
from 'gradle to '../gradlew'.

task cleanExample(type: Exec) {
    executable = '../gradlew'
    workingDir = project.file('hugo-example')
    ...
