### PR TITLE
Lower min_sdk_version to 7 (ECLAIR_MR1)

### DIFF
--- a/hugo-runtime/src/main/AndroidManifest.xml
+++ b/hugo-runtime/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     >
 
   <uses-sdk
-      android:minSdkVersion="9"/>
+      android:minSdkVersion="7"/>
 
   <application/>
 </manifest>


### PR DESCRIPTION
There is nothing stopping hugo from supporting min_sdk version of 7

`gradlew lint` says ok and the tests on the emulator agree
