### PR TITLE
Update travis.yml build tools and use android lang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
-language: java
+language: android
 
-jdk: oraclejdk7
+android:
+  components:
+    - build-tools-19.1.0
+
+env:
+  global:
+    - TERM=dumb
+  matrix:
+    - ANDROID_SDKS=android-19,sysimg-19  ANDROID_TARGET=android-19  ANDROID_ABI=armeabi-v7a
 
 before_install:
-  - export TERM=dumb
-  - sudo apt-get install -qq libstdc++6:i386 lib32z1
-  - export COMPONENTS=build-tools-19.0.3,android-19,extra-android-m2repository
-  - curl -L https://raw.github.com/embarkmobile/android-sdk-installer/version-1/android-sdk-installer | bash /dev/stdin --install=$COMPONENTS
-  - source ~/.android-sdk-installer/env
+  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
+  - emulator -avd test -no-skin -no-audio -no-window &
+
+before_script:
+  - adb wait-for-device
+  - adb shell input keyevent 82 &
 
 notifications:
   email: false


### PR DESCRIPTION
- Use travis android "language"
  
  Makes for faster builds and cleaner travis files
  More info: http://docs.travis-ci.com/user/languages/android
- No longer using external script for waiting for emulator
  Use `adb wait-for-device`
