### PR TITLE
Plugin check should check for extensions too

### DIFF
--- a/hugo-plugin/src/main/groovy/hugo/weaving/plugin/HugoPlugin.groovy
+++ b/hugo-plugin/src/main/groovy/hugo/weaving/plugin/HugoPlugin.groovy
@@ -11,8 +11,8 @@ import org.gradle.api.tasks.compile.JavaCompile
 
 class HugoPlugin implements Plugin<Project> {
   @Override void apply(Project project) {
-    def hasApp = project.plugins.hasPlugin(AppPlugin)
-    def hasLib = project.plugins.hasPlugin(LibraryPlugin)
+    def hasApp = project.plugins.withType(AppPlugin)
+    def hasLib = project.plugins.withType(LibraryPlugin)
     if (!hasApp && !hasLib) {
       throw new IllegalStateException("'android' or 'android-library' plugin required.")
     }


### PR DESCRIPTION
It is possible to subclass the "android" and "android-library" plugins. Using "withType" instead of "hasPlugin" will match these plugins.

For example, the [DexGuard](https://www.saikoa.com/dexguard) plugin subclasses and replaces the android plugin but "hasPlugin" still returns false.
