### PR TITLE
Update instructions to include mavenCentral()

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Add it to your project today!
 
 ```groovy
 buildscript {
+  repositories {
+    mavenCentral()
+  }
+
   dependencies {
     classpath 'com.jakewharton.hugo:hugo-plugin:1.1.0'
   }


### PR DESCRIPTION
Without finding this info in this log

http://logs.nslu2-linux.org/livelogs/android-dev/android-dev.20140506.txt

I’d not have known what the problem was.
