### PR TITLE
Update install task's path for fetching the aar artifact

### DIFF
--- a/hugo-runtime/build.gradle
+++ b/hugo-runtime/build.gradle
@@ -67,7 +67,7 @@ task install(type: Exec, dependsOn: assemble) {
       "-DartifactId=hugo-runtime",
       "-Dversion=${version}",
       "-Dpackaging=aar",
-      "-Dfile=build/libs/hugo-runtime-${version}.aar"
+      "-Dfile=build/outputs/aar/hugo-runtime-${version}.aar"
   ]
 }
 


### PR DESCRIPTION
This patch resolves a build error on the initial install task where the installation of the packaged aar to the local maven repo would fail. This appeared to be as a result of the new output directory structure of the android-library plugin. The (quick and easy fix) is to correct the output dir path.
