### PR TITLE
Update plugin name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'com.jakewharton.hugo'
+apply plugin: 'hugo'
 ```
 
 


### PR DESCRIPTION
Didn't work with `com.jakewharton.hugo` for me, but `hugo` did.
