### PR TITLE
Update README to use proper plugin name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'com.jakewharton.hugo'
+apply plugin: 'hugo'
 ```
 
 


### PR DESCRIPTION
Trying to apply the plugin 'com.jakewharton.hugo,' as specified in the README, failed for me. Taking a look at [u2020's build file](https://github.com/JakeWharton/u2020/blob/439bbb3a64526d2d08220f62b310547e3b143365/build.gradle#L20) and the [example's build file](https://github.com/JakeWharton/hugo/blob/489c9d125563ac5435ef19fa06317be14b810158/hugo-example/build.gradle#L25), found it used at 'hugo,' which worked :smile: 

Thanks for all the amazing projects!
