### PR TITLE
Add extension to disable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.jakewharton.hugo'
 ```
 
+Disable logging temporarily by adding the following:
+
+```groovy
+hugo {
+    logging false
+}
+```
 
 Local Development
 -----------------

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ hugo {
 }
 ```
 
+If you want to toggle logging at runtime, use `Hugo.setEnabled(true|false)`
+
 Local Development
 -----------------
 

--- a/hugo-plugin/src/main/groovy/hugo/weaving/plugin/HugoExtension.groovy
+++ b/hugo-plugin/src/main/groovy/hugo/weaving/plugin/HugoExtension.groovy
@@ -2,14 +2,14 @@ package hugo.weaving.plugin
 
 class HugoExtension {
 
-    def logging = true
+  def logging = true
 
-    def logging(boolean enabled) {
-        logging = enabled
-    }
+  def setLogging(boolean enabled) {
+    logging = enabled
+  }
 
-    def logging() {
-        return logging;
-    }
+  def getLogging() {
+    return logging;
+  }
 
 }

--- a/hugo-plugin/src/main/groovy/hugo/weaving/plugin/HugoExtension.groovy
+++ b/hugo-plugin/src/main/groovy/hugo/weaving/plugin/HugoExtension.groovy
@@ -1,0 +1,15 @@
+package hugo.weaving.plugin
+
+class HugoExtension {
+
+    def logging = true
+
+    def logging(boolean enabled) {
+        logging = enabled
+    }
+
+    def logging() {
+        return logging;
+    }
+
+}

--- a/hugo-plugin/src/main/groovy/hugo/weaving/plugin/HugoPlugin.groovy
+++ b/hugo-plugin/src/main/groovy/hugo/weaving/plugin/HugoPlugin.groovy
@@ -31,9 +31,14 @@ class HugoPlugin implements Plugin<Project> {
       compile 'com.jakewharton.hugo:hugo-annotations:1.2.2-SNAPSHOT'
     }
 
+    project.extensions.create('hugo', HugoExtension)
+
     variants.all { variant ->
       if (!variant.buildType.isDebuggable()) {
         log.debug("Skipping non-debuggable build type '${variant.buildType.name}'.")
+        return;
+      } else if (!project.hugo.logging) {
+        log.debug("Logging is disabled for '${variant.buildType.name}'.")
         return;
       }
 

--- a/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
+++ b/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
@@ -16,6 +16,9 @@ import java.util.concurrent.TimeUnit;
 
 @Aspect
 public class Hugo {
+
+  private static boolean sEnabled;
+
   @Pointcut("within(@hugo.weaving.DebugLog *)")
   public void withinAnnotatedClass() {}
 
@@ -30,6 +33,10 @@ public class Hugo {
 
   @Pointcut("execution(@hugo.weaving.DebugLog *.new(..)) || constructorInsideAnnotatedType()")
   public void constructor() {}
+
+  public static synchronized void setEnabled(boolean enabled) {
+    sEnabled = enabled;
+  }
 
   @Around("method() || constructor()")
   public Object logAndExecute(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -46,6 +53,10 @@ public class Hugo {
   }
 
   private static void enterMethod(JoinPoint joinPoint) {
+    if (!sEnabled) {
+      // Logging disabled
+      return;
+    }
     CodeSignature codeSignature = (CodeSignature) joinPoint.getSignature();
 
     Class<?> cls = codeSignature.getDeclaringType();
@@ -72,6 +83,10 @@ public class Hugo {
   }
 
   private static void exitMethod(JoinPoint joinPoint, Object result, long lengthMillis) {
+    if (!sEnabled) {
+      // Logging disabled
+      return;
+    }
     Signature signature = joinPoint.getSignature();
 
     Class<?> cls = signature.getDeclaringType();

--- a/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
+++ b/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 @Aspect
 public class Hugo {
 
-  private static boolean sEnabled;
+  private static volatile boolean enabled;
 
   @Pointcut("within(@hugo.weaving.DebugLog *)")
   public void withinAnnotatedClass() {}
@@ -34,8 +34,8 @@ public class Hugo {
   @Pointcut("execution(@hugo.weaving.DebugLog *.new(..)) || constructorInsideAnnotatedType()")
   public void constructor() {}
 
-  public static synchronized void setEnabled(boolean enabled) {
-    sEnabled = enabled;
+  public static void setEnabled(boolean enable) {
+    enabled = enable;
   }
 
   @Around("method() || constructor()")
@@ -53,7 +53,7 @@ public class Hugo {
   }
 
   private static void enterMethod(JoinPoint joinPoint) {
-    if (!sEnabled) {
+    if (!enabled) {
       // Logging disabled
       return;
     }
@@ -83,7 +83,7 @@ public class Hugo {
   }
 
   private static void exitMethod(JoinPoint joinPoint, Object result, long lengthMillis) {
-    if (!sEnabled) {
+    if (!enabled) {
       // Logging disabled
       return;
     }

--- a/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
+++ b/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 @Aspect
 public class Hugo {
 
-  private static volatile boolean enabled;
+  private static volatile boolean enabled = true;
 
   @Pointcut("within(@hugo.weaving.DebugLog *)")
   public void withinAnnotatedClass() {}


### PR DESCRIPTION
Enables globally disabling Hugo via build.gradle, which is much easier than going through and deleting a whole bunch of annotations that I will want again some day.