### PR TITLE
format parameter with quote

### DIFF
--- a/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
+++ b/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
@@ -69,8 +69,12 @@ public class Hugo {
       if (i > 0) {
         builder.append(", ");
       }
-      builder.append(parameterNames[i]).append('=');
+      builder.append("\'");
+      builder.append(parameterNames[i]);
+      builder.append("\'=");
+      builder.append("\'");
       builder.append(Strings.toString(parameterValues[i]));
+      builder.append("\'");
     }
     builder.append(')');
 


### PR DESCRIPTION
add Single quotes to method parameter.

for the complicated parameters can be more readable.
