### PR TITLE
Prevent execution of synthetics

### DIFF
--- a/hugo-example/src/main/java/com/example/hugo/HugoActivity.java
+++ b/hugo-example/src/main/java/com/example/hugo/HugoActivity.java
@@ -61,16 +61,15 @@ public class HugoActivity extends Activity {
     }, "I'm a lazy thr.. bah! whatever!").start();
   }
 
+  @DebugLog
   static class Greeter {
     private final String name;
 
-    @DebugLog
     Greeter(String name) {
       this.name = name;
     }
 
-    @DebugLog
-    public String sayHello() {
+    private String sayHello() {
       return "Hello, " + name;
     }
   }

--- a/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
+++ b/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
@@ -23,7 +23,7 @@ public class Hugo {
   @Pointcut("within(@hugo.weaving.DebugLog *)")
   public void withinAnnotatedClass() {}
 
-  @Pointcut("execution(* *(..)) && withinAnnotatedClass()")
+  @Pointcut("execution(!synthetic * *(..)) && withinAnnotatedClass()")
   public void methodInsideAnnotatedType() {}
 
   @Pointcut("execution(*.new(..)) && withinAnnotatedClass()")


### PR DESCRIPTION
Execution on synthetic methods of `@DebugLog` annotated classes is prevented. (Resolves [#111](https://github.com/JakeWharton/hugo/issues/111/))

Compiler generates a synthetic method after compiling, for example, an inner class with a private method like:

```java
public class HugoActivity extends Activity {
    //...
	@DebugLog
	static class Greeter {
		private final String name;

		Greeter(String name) {
		  this.name = name;
		}

		private String sayHello() {
		  return "Hello, " + name;
		}
	}
    //...
}
```

Before this, Hugo was logging for **access$000()** synthetic method too:

```
01-05 10:30:37.503  23503-23503/com.example.hugo V/Greeter﹕ ⇢ <init>(name="Jake")
01-05 10:30:37.503  23503-23503/com.example.hugo V/Greeter﹕ ⇠ <init> [0ms]
01-05 10:30:37.503  23503-23503/com.example.hugo V/Greeter﹕ ⇢ access$000(x0=com.example.hugo.HugoActivity$Greeter@3ca37d8)
01-05 10:30:37.504  23503-23503/com.example.hugo V/Greeter﹕ ⇢ sayHello()
01-05 10:30:37.504  23503-23503/com.example.hugo V/Greeter﹕ ⇠ sayHello [0ms] = "Hello, Jake"
01-05 10:30:37.504  23503-23503/com.example.hugo V/Greeter﹕ ⇠ access$000 [0ms] = "Hello, Jake"
```

With this, Hugo now logs:

```
01-05 10:30:37.503  23503-23503/com.example.hugo V/Greeter﹕ ⇢ <init>(name="Jake")
01-05 10:30:37.503  23503-23503/com.example.hugo V/Greeter﹕ ⇠ <init> [0ms]
01-05 10:30:37.504  23503-23503/com.example.hugo V/Greeter﹕ ⇢ sayHello()
01-05 10:30:37.504  23503-23503/com.example.hugo V/Greeter﹕ ⇠ sayHello [0ms] = "Hello, Jake"
```