### PR TITLE
Feature/prevent exec on synthetic constructors

### DIFF
--- a/hugo-example/src/main/java/com/example/hugo/HugoActivity.java
+++ b/hugo-example/src/main/java/com/example/hugo/HugoActivity.java
@@ -78,7 +78,7 @@ public class HugoActivity extends Activity {
   static class Charmer {
     private final String name;
 
-    Charmer(String name) {
+    private Charmer(String name) {
       this.name = name;
     }
 

--- a/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
+++ b/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
@@ -26,7 +26,7 @@ public class Hugo {
   @Pointcut("execution(!synthetic * *(..)) && withinAnnotatedClass()")
   public void methodInsideAnnotatedType() {}
 
-  @Pointcut("execution(*.new(..)) && withinAnnotatedClass()")
+  @Pointcut("execution(!synthetic *.new(..)) && withinAnnotatedClass()")
   public void constructorInsideAnnotatedType() {}
 
   @Pointcut("execution(@hugo.weaving.DebugLog * *(..)) || methodInsideAnnotatedType()")


### PR DESCRIPTION
Just like preventing synthetic methods' logging (resolved in #112), synthetic constructor of a `@DebugLog` annotated inner class also should not be logged by Hugo.

*Note: When the private constructor of an inner class is used, in addition to the synthetic constructor, an empty class will be created by compiler. At least for now, this is not a problem for Hugo. (i.e. Hugo is interested in methods and constructors.)*

To demonstrate, access modifier of `Charmer` class' constructor is changed to `private`.

Before this, Hugo was logging for `Charmer` class' synthetic constructor too:
```
01-20 18:30:26.904    4298-4298/com.example.hugo V/Charmer﹕ ⇢ <init>(name="Jake")
01-20 18:30:26.905    4298-4298/com.example.hugo V/Charmer﹕ ⇠ <init> [0ms]
01-20 18:30:26.905    4298-4298/com.example.hugo V/Charmer﹕ ⇢ <init>(x0="Jake", x1=null)
01-20 18:30:26.905    4298-4298/com.example.hugo V/Charmer﹕ ⇠ <init> [0ms]
```

With this, Hugo now logs:
```
01-20 18:31:24.261    8835-8835/com.example.hugo V/Charmer﹕ ⇢ <init>(name="Jake")
01-20 18:31:24.261    8835-8835/com.example.hugo V/Charmer﹕ ⇠ <init> [0ms]
```