### PR TITLE
Add support for proper Tag naming for methods within an Enum

### DIFF
--- a/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
+++ b/hugo-runtime/src/main/java/hugo/weaving/internal/Hugo.java
@@ -116,8 +116,17 @@ public class Hugo {
 
   private static String asTag(Class<?> cls) {
     if (cls.isAnonymousClass()) {
-      return asTag(cls.getEnclosingClass());
+      final Class<?> enclosingClass = cls.getEnclosingClass();
+      if (enclosingClass.isEnum()) {
+        String splits[] = cls.getName().split("\\$");
+        return enumAsTag(enclosingClass, Integer.parseInt(splits[splits.length-1]));
+      }
+      return asTag(enclosingClass);
     }
     return cls.getSimpleName();
+  }
+
+  private static String enumAsTag(Class<?> enclosingClass, int enumIdx) {
+    return ((Enum)enclosingClass.getEnumConstants()[enumIdx]).name();
   }
 }


### PR DESCRIPTION
Currently the code will name the tag after the enclosing enum, this update will name the Tag according to the enum element name.
